### PR TITLE
Fix failure to show all available shows

### DIFF
--- a/default.py
+++ b/default.py
@@ -68,7 +68,7 @@ def get_api_token(type = 'ninemsnCatchup'):
 
 @plugin.route('/')
 def index():
-  data = load_json(TV_CAT_API_URL + '/shows?take=200')
+  data = load_json(TV_CAT_API_URL + '/shows?take=-1')
   shows = filter(filter_has_episodes, filter(filter_drm_shows, data['payload']))
   items = map(show_data_to_xbmc_dict, shows)
   plugin.set_content('tvshows')


### PR DESCRIPTION
Prior to this change the loaded show list is limited to 200 results. This can mean shows do not appear in the list.

This change retreives all show information (which may be more data-intensive).
