### PR TITLE
Proof of concept: speed up plugin navigation

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -11,6 +11,7 @@
     <provides>video</provides>
   </extension>
   <extension library="default.py" point="xbmc.addon.metadata">
+    <reuselanguageinvoker>true</reuselanguageinvoker>
     <summary>9now add-on</summary>
     <description>Watch live TV and catch up on all videos offered by the 9now service</description>
     <provides>video</provides>

--- a/resources/lib/classes.py
+++ b/resources/lib/classes.py
@@ -5,6 +5,8 @@ import json
 import datetime
 import xbmcgui
 
+from config import USER_AGENT
+
 from threading import Thread
 from collections import deque
 
@@ -180,6 +182,9 @@ class CacheObj():
                 name=None, noCache=False, expiry=None, data=None):
 
         now = datetime.datetime.now()
+
+        if not headers or not headers.get('User-Agent'):
+            headers['User-Agent'] = USER_AGENT
 
         if noCache or not name:
             data = CacheObj.fetch_url(url=url, headers=headers)

--- a/resources/lib/classes.py
+++ b/resources/lib/classes.py
@@ -56,6 +56,7 @@ class series(object):
         self.season_slug = None
         self.title = None
         self.genre = None
+        self.genre_slug = None
         self.desc = None
 
     def __repr__(self):

--- a/resources/lib/classes.py
+++ b/resources/lib/classes.py
@@ -1,14 +1,30 @@
 import urlparse
 import urllib
 import unicodedata
+import json
+import datetime
+import xbmcgui
+
+from collections import deque
+
+from aussieaddonscommon import session
+from aussieaddonscommon import utils
 
 
 class genre(object):
-    def __init__(self):
+    def __init__(self, attrs=None):
+        if attrs:
+            for attr, val in attrs.items():
+                setattr(self, attr, val)
+            return
+
         self.fanart = None
         self.thumb = None
         self.title = None
         self.genre_slug = None
+
+    def __repr__(self):
+        return type(self).__name__ + '(' + str(dict(vars(self).items())) + ')'
 
     def make_kodi_url(self):
         d = vars(self)
@@ -25,7 +41,12 @@ class genre(object):
 
 
 class series(object):
-    def __init__(self):
+    def __init__(self, attrs=None):
+        if attrs:
+            for attr, val in attrs.items():
+                setattr(self, attr, val)
+            return
+
         self.multi_season = None
         self.fanart = None
         self.thumb = None
@@ -35,6 +56,10 @@ class series(object):
         self.season_slug = None
         self.title = None
         self.genre = None
+        self.desc = None
+
+    def __repr__(self):
+        return type(self).__name__ + '(' + str(dict(vars(self).items())) + ')'
 
     def get_title(self):
         if self.multi_season:
@@ -60,7 +85,12 @@ class series(object):
 
 
 class episode(object):
-    def __init__(self):
+    def __init__(self, attrs=None):
+        if attrs:
+            for attr, val in attrs.items():
+                setattr(self, attr, val)
+            return
+
         self.fanart = None
         self.thumb = None
         self.title = None
@@ -73,6 +103,9 @@ class episode(object):
         self.drm = None
         self.license_url = None
         self.license_key = None
+
+    def __repr__(self):
+        return type(self).__name__ + '(' + str(dict(vars(self).items())) + ')'
 
     def get_title(self):
         return 'Ep {0} - {1}'.format(self.episode_no, self.episode_name)
@@ -98,7 +131,12 @@ class episode(object):
 
 
 class channel(object):
-    def __init__(self):
+    def __init__(self, attrs=None):
+        if attrs:
+            for attr, val in attrs.items():
+                setattr(self, attr, val)
+            return
+
         self.fanart = None
         self.thumb = None
         self.title = None
@@ -107,6 +145,9 @@ class channel(object):
         self.url = None
         self.id = None
         self.drm = None
+
+    def __repr__(self):
+        return type(self).__name__ + '(' + str(dict(vars(self).items())) + ')'
 
     def get_title(self):
         return '{0} - {1}'.format(self.title, self.desc)
@@ -123,3 +164,70 @@ class channel(object):
         params = urlparse.parse_qsl(url)
         for item in params.keys():
             setattr(self, item, urllib.unquote_plus(params[item]))
+
+
+class CacheObj():
+
+    maxEntries = 50
+    maxTTL = datetime.timedelta(seconds=(60*60*12))
+
+    def __init__(self):
+        self.win = xbmcgui.Window(10000)
+
+    def getData(self, url, headers={},
+                name=None, noCache=False, expiry=None, data=None):
+
+        now = datetime.datetime.now()
+
+        if noCache or not name:
+            return CacheObj.fetch_url(url=url, headers=headers)
+
+        if not data:
+            rawData = self.win.getProperty('%s|%s' % (name, url))
+            if rawData:
+                try:
+                    cachedData = eval(rawData)
+                    if cachedData[0] > now:
+                        return cachedData[1]
+                except Exception as e:
+                    utils.log('Error with eval of cached data: {0}'.format(e))
+                    #utils.log(rawData)
+
+        if not isinstance(expiry, datetime.datetime):
+            expiry = now + CacheObj.maxTTL
+
+        if not data:
+            data = CacheObj.fetch_url(url=url, headers=headers)
+
+        cachedData = (expiry, data)
+        self.win.setProperty('%s|%s' % (name, url), repr(cachedData))
+
+        rawURLs = self.win.getProperty('%s|urls' % name)
+        urls = eval(rawURLs) if rawURLs else deque()
+
+        if url in urls:
+            urls.remove(url)
+        urls.append(url)
+
+        if len(urls) > CacheObj.maxEntries:
+            oldUrl = urls.popleft()
+            self.win.setProperty('%s|%s' % (name, oldUrl), '')
+
+        self.win.setProperty('%s|urls' % name, repr(urls))
+
+        return cachedData[1]
+
+    @staticmethod
+    def fetch_url(url, headers={}):
+        """
+        Use custom session to grab URL and return the text
+        """
+        with session.Session(force_tlsv1=True) as sess:
+            res = sess.get(url, headers=headers)
+            try:
+                data = json.loads(res.text)
+                return data
+            except ValueError as e:
+                utils.log('Error parsing JSON, response is {0}'
+                            .format(res.text))
+                raise e

--- a/resources/lib/classes.py
+++ b/resources/lib/classes.py
@@ -211,7 +211,7 @@ class CacheObj():
 
         if len(urls) > CacheObj.maxEntries:
             oldUrl = urls.popleft()
-            self.win.setProperty('%s|%s' % (name, oldUrl), '')
+            self.win.clearProperty('%s|%s' % (name, oldUrl))
 
         self.win.setProperty('%s|urls' % name, repr(urls))
 

--- a/resources/lib/classes.py
+++ b/resources/lib/classes.py
@@ -187,19 +187,18 @@ class CacheObj():
             if rawData:
                 try:
                     cachedData = eval(rawData)
-                    if cachedData[0] > now:
+                    if not isinstance(expiry, datetime.timedelta):
+                        expiry = CacheObj.maxTTL
+                    if cachedData[0] + expiry > now:
                         return cachedData[1]
                 except Exception as e:
                     utils.log('Error with eval of cached data: {0}'.format(e))
                     #utils.log(rawData)
 
-        if not isinstance(expiry, datetime.datetime):
-            expiry = now + CacheObj.maxTTL
-
         if not data:
             data = CacheObj.fetch_url(url=url, headers=headers)
 
-        cachedData = (expiry, data)
+        cachedData = (now, data)
         self.win.setProperty('%s|%s' % (name, url), repr(cachedData))
 
         rawURLs = self.win.getProperty('%s|urls' % name)

--- a/resources/lib/classes.py
+++ b/resources/lib/classes.py
@@ -92,6 +92,10 @@ class episode(object):
                 setattr(self, attr, val)
             return
 
+        self.series_slug = None
+        self.series_title = None
+        self.season_slug = None
+        self.season_no = None
         self.fanart = None
         self.thumb = None
         self.title = None
@@ -110,12 +114,6 @@ class episode(object):
 
     def get_title(self):
         return 'Ep {0} - {1}'.format(self.episode_no, self.episode_name)
-
-    def get_airdate(self):
-        if self.airdate:
-            return '{0}.{1}.{2}'.format(self.airdate[8:10],
-                                        self.airdate[5:7],
-                                        self.airdate[0:4])
 
     def make_kodi_url(self):
         d = vars(self)

--- a/resources/lib/classes.py
+++ b/resources/lib/classes.py
@@ -101,6 +101,7 @@ class episode(object):
         self.thumb = None
         self.title = None
         self.desc = None
+        self.duration = None
         self.airdate = None
         self.episode_no = None
         self.episode_name = None

--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -224,7 +224,8 @@ def get_subtitles(text_tracks):
     for text_track in text_tracks:
         try:
             sub_url = text_track.get('src')
-            if sub_url:
+            label = text_track.get('label')
+            if sub_url and label != 'thumbnails':
                 return sub_url
         except AttributeError:
             pass

--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -36,15 +36,11 @@ def fetch_bc_url(url, headers={}):
             raise e
 
 
-def list_series(genre=None):
+def list_series():
     """
     Create and return list of series objects
     """
-    if genre:
-        url = config.TVSERIESQUERY_URL.format(genre)
-    else:
-        url = config.TVSERIES_URL
-    data = cache.getData(name=ADDON_ID, url=url)
+    data = cache.getData(name=ADDON_ID, url=config.TVSERIES_URL)
 
     if isinstance(data, list):
         return data
@@ -62,13 +58,30 @@ def list_series(genre=None):
                 s.fanart = show['image']['sizes'].get('w1280')
                 s.thumb = season['image']['sizes'].get('w480')
                 s.genre = season['genre'].get('name')
+                s.genre_slug = season['genre'].get('slug')
                 s.title = s.get_title()
                 s.desc = season.get('description')
                 listing.append(s)
 
-    cache.getData(name=ADDON_ID, url=url, data=listing)
+    cache.getData(name=ADDON_ID, url=config.TVSERIES_URL, data=listing)
     return listing
 
+
+def list_series_by_genre(genre):
+    """
+    Create and return list of series objects
+    """
+    url = config.TVSERIESQUERY_URL.format(genre)
+    data = cache.getData(name=ADDON_ID, url=url)
+
+    if isinstance(data, list):
+        return data
+
+    data = data.get('tvSeries', None)
+    listing = [s['slug'] for s in data] if data else []
+
+    cache.getData(name=ADDON_ID, url=url, data=listing)
+    return listing
 
 def list_genres():
     """

--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -147,6 +147,9 @@ def list_episodes(params):
     data = cache.getData(name=ADDON_ID, url=url)
 
     if isinstance(data, list):
+        if params.get('episode'):
+            return [e for e in data
+                        if e.episode_no == str(params.get('episode'))]
         return data
 
     episodes = []
@@ -162,6 +165,9 @@ def list_episodes(params):
             listing.append(e)
 
     cache.getData(name=ADDON_ID, url=url, data=listing)
+    if params.get('episode'):
+        return [e for e in listing
+                    if e.episode_no == str(params.get('episode'))]
     return listing
 
 
@@ -171,7 +177,8 @@ def get_next_episode(episode):
 
     params = dict(series_slug=episode['series_slug'],
                   season_slug=episode['season_slug'],
-                  episode_slug='episode-%s' % str(int(episode['episode_no'])+1))
+                  #episode_slug='episode-%s' % str(int(episode['episode_no'])+1),
+                  episode=int(episode['episode_no'])+1)
 
     episodes = list_episodes(params)
     return episodes[0] if episodes else None

--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -153,10 +153,12 @@ def list_episodes(params):
         return data
 
     episodes = []
-    if 'episodes' in data:
-        episodes = data['episodes'].get('items')
-    elif 'episode' in data:
+    if 'episode' in data:
         episodes = [data['episode']]
+    elif 'episodes' in data:
+        episodes = data['episodes'].get('items')
+    elif 'items' in data:
+        episodes = data['items']
 
     listing = []
     for episode in episodes:

--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -36,11 +36,15 @@ def fetch_bc_url(url, headers={}):
             raise e
 
 
-def list_series():
+def list_series(genre=None):
     """
     Create and return list of series objects
     """
-    data = cache.getData(name=ADDON_ID, url=config.TVSERIES_URL)
+    if genre:
+        url = config.TVSERIESQUERY_URL.format(genre)
+    else:
+        url = config.TVSERIES_URL
+    data = cache.getData(name=ADDON_ID, url=url)
 
     if isinstance(data, list):
         return data
@@ -62,7 +66,7 @@ def list_series():
                 s.desc = season.get('description')
                 listing.append(s)
 
-    cache.getData(name=ADDON_ID, url=config.TVSERIES_URL, data=listing)
+    cache.getData(name=ADDON_ID, url=url, data=listing)
     return listing
 
 

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -9,7 +9,7 @@ CATEGORIES = ['Live TV', 'All Shows']
 GENRES_URL = "https://tv-api.9now.com.au/v1/genres?device=android&take=99999"
 TVSERIES_URL = "https://tv-api.9now.com.au/v1/tv-series?device=android&take=99999"
 TVSERIESQUERY_URL = "https://tv-api.9now.com.au/v1/pages/genres/{0}?device=web&take=99999"
-EPISODEQUERY_URL = "https://tv-api.9now.com.au/v1/pages/tv-series/{0}/seasons/{1}?device=android"
+EPISODEQUERY_URL = "https://tv-api.9now.com.au/v1/pages/tv-series/{0}/seasons/{1}/episodes/{2}?device=android"
 LIVETV_URL = "https://tv-api.9now.com.au/v1/pages/livestreams?device=android"
 
 BRIGHTCOVE_URL = "http://c.brightcove.com/services/mobile/streaming/index/master.m3u8?videoId={0}"

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -10,7 +10,7 @@ GENRES_URL = "https://tv-api.9now.com.au/v1/genres?device=android&take=99999"
 TVSERIES_URL = "https://tv-api.9now.com.au/v1/tv-series?device=android&take=99999"
 TVSERIESQUERY_URL = "https://tv-api.9now.com.au/v1/pages/genres/{0}?device=web&take=99999"
 EPISODEQUERY_URL = "https://tv-api.9now.com.au/v1/pages/tv-series/{0}/seasons/{1}/episodes/{2}?device=android"
-LIVETV_URL = "https://tv-api.9now.com.au/v1/pages/livestreams?device=android"
+LIVETV_URL = "https://tv-api.9now.com.au/v1/pages/livestreams?device=web"
 
 BRIGHTCOVE_URL = "http://c.brightcove.com/services/mobile/streaming/index/master.m3u8?videoId={0}"
 BRIGHTCOVE_DRM_URL = "https://edge.api.brightcove.com/playback/v1/accounts/{0}/videos/ref:{1}"

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -6,15 +6,17 @@ ISSUE_API_AUTH = 'eGJtY2JvdDo1OTQxNTJjMTBhZGFiNGRlN2M0YWZkZDYwZGQ5NDFkNWY4YmIzOG
 GIST_API_URL = 'https://api.github.com/gists'
 
 CATEGORIES = ['Live TV', 'All Shows']
-GENRES_URL = "https://tv-api.9now.com.au/v1/genres?device=android&take=99999"
-TVSERIES_URL = "https://tv-api.9now.com.au/v1/tv-series?device=android&take=99999"
-TVSERIESQUERY_URL = "https://tv-api.9now.com.au/v1/pages/genres/{0}?device=web&take=99999"
-EPISODEQUERY_URL = "https://tv-api.9now.com.au/v1/pages/tv-series/{0}/seasons/{1}/episodes/{2}?device=android"
-LIVETV_URL = "https://tv-api.9now.com.au/v1/pages/livestreams?device=web"
+GENRES_URL = "https://tv-api.9now.com.au/v2/genres?device=web"
+TVSERIES_URL = "https://tv-api.9now.com.au/v2/tv-series?device=web"
+TVSERIESQUERY_URL = "https://tv-api.9now.com.au/v2/pages/genres/{0}?device=web"
+EPISODEQUERY_URL = "https://tv-api.9now.com.au/v2/pages/tv-series/{0}/seasons/{1}/episodes{2}?device=web"
+LIVETV_URL = "https://tv-api.9now.com.au/v2/pages/livestreams?device=web"
 
 BRIGHTCOVE_URL = "http://c.brightcove.com/services/mobile/streaming/index/master.m3u8?videoId={0}"
 BRIGHTCOVE_DRM_URL = "https://edge.api.brightcove.com/playback/v1/accounts/{0}/videos/ref:{1}"
 BRIGHTCOVE_ACCOUNT = "4460760524001"
 BRIGHTCOVE_KEY = "BCpkADawqM1TWX5yhWjKdzhXnHCmGvnaozGSDICiEFNRv0fs12m6WA2hLxMHM8TGAEM6pv7lhJsdNhiQi76p4IcsT_jmXdtEU-wnfXhOBTx-cGR7guCqVwjyFAtQa75PFF-TmWESuiYaNTzg"
+
+USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36'
 
 MAX_HLS_QUAL = 4

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -8,7 +8,7 @@ GIST_API_URL = 'https://api.github.com/gists'
 CATEGORIES = ['Live TV', 'All Shows']
 GENRES_URL = "https://tv-api.9now.com.au/v1/genres?device=android&take=99999"
 TVSERIES_URL = "https://tv-api.9now.com.au/v1/tv-series?device=android&take=99999"
-TVSERIESQUERY_URL = "https://tv-api.9now.com.au/v1/pages/genres/{0}?device=android&take=99999"
+TVSERIESQUERY_URL = "https://tv-api.9now.com.au/v1/pages/genres/{0}?device=web&take=99999"
 EPISODEQUERY_URL = "https://tv-api.9now.com.au/v1/pages/tv-series/{0}/seasons/{1}?device=android"
 LIVETV_URL = "https://tv-api.9now.com.au/v1/pages/livestreams?device=android"
 

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -8,6 +8,7 @@ GIST_API_URL = 'https://api.github.com/gists'
 CATEGORIES = ['Live TV', 'All Shows']
 GENRES_URL = "https://tv-api.9now.com.au/v1/genres?device=android&take=99999"
 TVSERIES_URL = "https://tv-api.9now.com.au/v1/tv-series?device=android&take=99999"
+TVSERIESQUERY_URL = "https://tv-api.9now.com.au/v1/pages/genres/{0}?device=android&take=99999"
 EPISODEQUERY_URL = "https://tv-api.9now.com.au/v1/pages/tv-series/{0}/seasons/{1}?device=android"
 LIVETV_URL = "https://tv-api.9now.com.au/v1/pages/livestreams?device=android"
 

--- a/resources/lib/menu.py
+++ b/resources/lib/menu.py
@@ -58,12 +58,17 @@ def make_episodes_list(url):
             li.setProperty('IsPlayable', 'true')
             if e.drm is True:
                 li.setProperty('inputstreamaddon', 'inputstream.adaptive')
+                li.setProperty('inputstream.adaptive.manifest_type', 'mpd')
             li.setInfo('video', {'plot': e.desc,
                                  'plotoutline': e.desc,
                                  'duration': e.duration,
                                  'date': e.get_airdate()})
             listing.append((url, li, is_folder))
 
+        xbmcplugin.addSortMethod(
+            _handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE)
+        xbmcplugin.addSortMethod(
+            _handle, xbmcplugin.SORT_METHOD_EPISODE)
         xbmcplugin.addDirectoryItems(_handle, listing, len(listing))
         xbmcplugin.endOfDirectory(_handle)
     except Exception:

--- a/resources/lib/menu.py
+++ b/resources/lib/menu.py
@@ -62,7 +62,7 @@ def make_episodes_list(url):
             li.setInfo('video', {'plot': e.desc,
                                  'plotoutline': e.desc,
                                  'duration': e.duration,
-                                 'date': e.get_airdate()})
+                                 'date': e.airdate})
             listing.append((url, li, is_folder))
 
         xbmcplugin.addSortMethod(

--- a/resources/lib/menu.py
+++ b/resources/lib/menu.py
@@ -12,6 +12,15 @@ _url = sys.argv[0]
 _handle = int(sys.argv[1])
 
 
+def create_listitem(*args, **kwargs):
+    ver = utils.get_kodi_major_version()
+    if ver >= 18:
+        kwargs['offscreen'] = True
+
+    listitem = xbmcgui.ListItem(*args, **kwargs)
+    return listitem
+
+
 def list_categories():
     """
     Make initial list
@@ -20,7 +29,7 @@ def list_categories():
         listing = []
         categories = config.CATEGORIES
         for category in categories:
-            li = xbmcgui.ListItem(category, offscreen=True)
+            li = create_listitem(category)
             url_string = '{0}?action=listcategories&category={1}'
             url = url_string.format(_url, category)
             is_folder = True
@@ -28,14 +37,17 @@ def list_categories():
 
         genres = comm.list_genres()
         for g in genres:
-            li = xbmcgui.ListItem(g.title, iconImage=g.thumb,
-                                  thumbnailImage=g.thumb, offscreen=True)
+            li = create_listitem(
+                g.title,
+                iconImage=g.thumb,
+                thumbnailImage=g.thumb
+            )
             li.setArt({'fanart': g.fanart})
             url_string = '{0}?action=listcategories&category=genre&genre={1}'
             url = url_string.format(_url, urllib.quote_plus(g.genre_slug))
             is_folder = True
             listing.append((url, li, is_folder))
-        li = xbmcgui.ListItem('Settings', offscreen=True)
+        li = create_listitem('Settings')
         listing.append(('{0}?action=settings'.format(_url), li, is_folder))
         xbmcplugin.addDirectoryItems(_handle, listing, len(listing))
         xbmcplugin.endOfDirectory(_handle)
@@ -50,8 +62,11 @@ def make_episodes_list(url):
         episodes = comm.list_episodes(params)
         listing = []
         for e in episodes:
-            li = xbmcgui.ListItem(e.title, iconImage=e.thumb,
-                                  thumbnailImage=e.thumb, offscreen=True)
+            li = create_listitem(
+                e.title,
+                iconImage=e.thumb,
+                thumbnailImage=e.thumb
+            )
             li.setArt({'fanart': e.fanart})
             url = '{0}?action=listepisodes{1}'.format(_url, e.make_kodi_url())
             is_folder = False
@@ -82,8 +97,11 @@ def make_live_list(url):
         channels = comm.list_live(params)
         listing = []
         for c in channels:
-            li = xbmcgui.ListItem(c.title, iconImage=c.thumb,
-                                  thumbnailImage=c.thumb, offscreen=True)
+            li = create_listitem(
+                c.title,
+                iconImage=c.thumb,
+                thumbnailImage=c.thumb
+            )
             li.setArt({'fanart': c.fanart})
             url = '{0}?action=listchannels{1}'.format(_url, c.make_kodi_url())
             is_folder = False
@@ -109,8 +127,11 @@ def make_series_list(url):
                             if s.series_slug in series_slug_list]
         listing = []
         for s in series_list:
-            li = xbmcgui.ListItem(s.title, iconImage=s.thumb,
-                                  thumbnailImage=s.thumb, offscreen=True)
+            li = create_listitem(
+                s.title,
+                iconImage=s.thumb,
+                thumbnailImage=s.thumb
+            )
             li.setArt({'fanart': s.fanart})
             url = '{0}?action=listseries{1}'.format(_url, s.make_kodi_url())
             is_folder = True

--- a/resources/lib/menu.py
+++ b/resources/lib/menu.py
@@ -20,7 +20,7 @@ def list_categories():
         listing = []
         categories = config.CATEGORIES
         for category in categories:
-            li = xbmcgui.ListItem(category)
+            li = xbmcgui.ListItem(category, offscreen=True)
             url_string = '{0}?action=listcategories&category={1}'
             url = url_string.format(_url, category)
             is_folder = True
@@ -29,13 +29,13 @@ def list_categories():
         genres = comm.list_genres()
         for g in genres:
             li = xbmcgui.ListItem(g.title, iconImage=g.thumb,
-                                  thumbnailImage=g.thumb)
+                                  thumbnailImage=g.thumb, offscreen=True)
             li.setArt({'fanart': g.fanart})
             url_string = '{0}?action=listcategories&category=genre&genre={1}'
             url = url_string.format(_url, urllib.quote_plus(g.title))
             is_folder = True
             listing.append((url, li, is_folder))
-        li = xbmcgui.ListItem('Settings')
+        li = xbmcgui.ListItem('Settings', offscreen=True)
         listing.append(('{0}?action=settings'.format(_url), li, is_folder))
         xbmcplugin.addDirectoryItems(_handle, listing, len(listing))
         xbmcplugin.endOfDirectory(_handle)
@@ -51,7 +51,7 @@ def make_episodes_list(url):
         listing = []
         for e in episodes:
             li = xbmcgui.ListItem(e.title, iconImage=e.thumb,
-                                  thumbnailImage=e.thumb)
+                                  thumbnailImage=e.thumb, offscreen=True)
             li.setArt({'fanart': e.fanart})
             url = '{0}?action=listepisodes{1}'.format(_url, e.make_kodi_url())
             is_folder = False
@@ -78,7 +78,7 @@ def make_live_list(url):
         listing = []
         for c in channels:
             li = xbmcgui.ListItem(c.title, iconImage=c.thumb,
-                                  thumbnailImage=c.thumb)
+                                  thumbnailImage=c.thumb, offscreen=True)
             li.setArt({'fanart': c.fanart})
             url = '{0}?action=listchannels{1}'.format(_url, c.make_kodi_url())
             is_folder = False
@@ -109,7 +109,7 @@ def make_series_list(url):
         listing = []
         for s in filtered:
             li = xbmcgui.ListItem(s.title, iconImage=s.thumb,
-                                  thumbnailImage=s.thumb)
+                                  thumbnailImage=s.thumb, offscreen=True)
             li.setArt({'fanart': s.fanart})
             url = '{0}?action=listseries{1}'.format(_url, s.make_kodi_url())
             is_folder = True

--- a/resources/lib/menu.py
+++ b/resources/lib/menu.py
@@ -32,7 +32,7 @@ def list_categories():
                                   thumbnailImage=g.thumb, offscreen=True)
             li.setArt({'fanart': g.fanart})
             url_string = '{0}?action=listcategories&category=genre&genre={1}'
-            url = url_string.format(_url, urllib.quote_plus(g.title))
+            url = url_string.format(_url, urllib.quote_plus(g.genre_slug))
             is_folder = True
             listing.append((url, li, is_folder))
         li = xbmcgui.ListItem('Settings', offscreen=True)
@@ -103,16 +103,12 @@ def make_series_list(url):
     try:
         params = dict(urlparse.parse_qsl(url))
         series_list = comm.list_series()
-        filtered = []
         if 'genre' in params:
-            for s in series_list:
-                if s.genre == urllib.unquote_plus(params['genre']):
-                    filtered.append(s)
-        else:
-            filtered = series_list
-
+            series_slug_list = comm.list_series_by_genre(params['genre'])
+            series_list = [s for s in series_list
+                            if s.series_slug in series_slug_list]
         listing = []
-        for s in filtered:
+        for s in series_list:
             li = xbmcgui.ListItem(s.title, iconImage=s.thumb,
                                   thumbnailImage=s.thumb, offscreen=True)
             li.setArt({'fanart': s.fanart})

--- a/resources/lib/menu.py
+++ b/resources/lib/menu.py
@@ -135,6 +135,7 @@ def make_series_list(url):
             li.setArt({'fanart': s.fanart})
             url = '{0}?action=listseries{1}'.format(_url, s.make_kodi_url())
             is_folder = True
+            li.setInfo('video', {'plot': s.desc, 'plotoutline': s.desc})
             listing.append((url, li, is_folder))
 
         xbmcplugin.addSortMethod(

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -86,6 +86,7 @@ def play_video(params):
             url = widevine['url']
             sub_url = widevine['sub_url']
             play_item = xbmcgui.ListItem(path=url)
+            play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
             play_item.setProperty('inputstream.adaptive.manifest_type',
                                   'mpd')
             play_item.setProperty('inputstream.adaptive.license_type',
@@ -134,6 +135,9 @@ def play_video(params):
 
             except Exception as e:
                 utils.log('Unable to add subtitles: {0}'.format(e))
+
+        play_item.setProperty('isPlayable', 'true')
+        play_item.setIsFolder(False)
 
         xbmcplugin.setResolvedUrl(_handle, True, play_item)
 

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -138,7 +138,8 @@ def play_video(params):
                 utils.log('Unable to add subtitles: {0}'.format(e))
 
         play_item.setProperty('isPlayable', 'true')
-        play_item.setIsFolder(False)
+        if hasattr(play_item, 'setIsFolder'):
+            play_item.setIsFolder(False)
         # TODO: add more info
         play_item.setInfo('video', {
             'mediatype': 'episode',

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -142,14 +142,14 @@ def play_video(params):
         play_item.setIsFolder(False)
         #TODO: add more info
         play_item.setInfo('video', {'mediatype': 'episode',
-                                    'tvshowtitle': params['series_title'],
+                                    'tvshowtitle': params.get('series_title',''),
                                     'title': params['episode_name'],
                                     'plot': params['desc'],
                                     'plotoutline': params['desc'],
-                                    'duration': params['duration'],
-                                    'aired': params['airdate'],
-                                    'season': params['season_no'],
-                                    'episode': params['episode_no']})
+                                    'duration': params.get('duration',''),
+                                    'aired': params.get('airdate',''),
+                                    'season': params.get('season_no',''),
+                                    'episode': params.get('episode_no','')})
 
         xbmcplugin.setResolvedUrl(_handle, True, play_item)
 

--- a/resources/lib/upnext.py
+++ b/resources/lib/upnext.py
@@ -2,7 +2,7 @@ import xbmc
 from json import dumps, loads
 from base64 import b64encode
 
-def upnext_signal(sender, next_info):
+def send_signal(sender, next_info):
     """Send a signal to Kodi using JSON RPC"""
     data = [to_unicode(b64encode(dumps(next_info).encode()))]
     notify(sender=sender + '.SIGNAL', message='upnext_data', data=data)

--- a/resources/lib/upnext.py
+++ b/resources/lib/upnext.py
@@ -1,0 +1,35 @@
+import xbmc
+from json import dumps, loads
+from base64 import b64encode
+
+def upnext_signal(sender, next_info):
+    """Send a signal to Kodi using JSON RPC"""
+    data = [to_unicode(b64encode(dumps(next_info).encode()))]
+    notify(sender=sender + '.SIGNAL', message='upnext_data', data=data)
+
+def notify(sender, message, data):
+    """Send a notification to Kodi using JSON RPC"""
+    result = jsonrpc(method='JSONRPC.NotifyAll', params=dict(
+        sender=sender,
+        message=message,
+        data=data,
+    ))
+    if result.get('result') != 'OK':
+        xbmc.log('Failed to send notification: '
+                    + result.get('error').get('message'))
+        return False
+    return True
+
+def jsonrpc(**kwargs):
+    """Perform JSONRPC calls"""
+    if kwargs.get('id') is None:
+        kwargs.update(id=0)
+    if kwargs.get('jsonrpc') is None:
+        kwargs.update(jsonrpc='2.0')
+    return loads(xbmc.executeJSONRPC(dumps(kwargs)))
+
+def to_unicode(text, encoding='utf-8', errors='strict'):
+    """Force text to unicode"""
+    if isinstance(text, bytes):
+        return text.decode(encoding, errors=errors)
+    return text


### PR DESCRIPTION
There is probably a better way to do this... but this PR tries to speed up plugin navigation by implementing the following:
- cache 9Now API request JSON response data
- filter shows by primary and secondary genres
- cache processed/filtered data
- offscreen ListItem creation

The cache just stores serialised data as a window property. 50 items are stored for 12 hours.

TODO:

- [ ] method to flush cache
- [ ] method to manually refresh plugin directory listings
- [x] method to request API data in background ~~then compare to cached data~~ to ensure directory listings are always fresh ~~(maybe)~~
- [ ] addon settings for cache (maybe)